### PR TITLE
Fix area comment for AOD retrieval

### DIFF
--- a/pronostico_pm_cams.py
+++ b/pronostico_pm_cams.py
@@ -47,7 +47,7 @@ client.retrieve(
     }
 ).download("data_polvo.zip")
 
-# Descarga de AOD para el área extendida [-100, 0] x [0, 30]
+# Descarga de AOD para el área extendida [north, west, south, east] = [30, -100, 0, 0]
 client.retrieve(
     "cams-global-atmospheric-composition-forecasts",
     {


### PR DESCRIPTION
## Summary
- clarify the AOD retrieval comment to specify the `[north, west, south, east]` order

## Testing
- `python -m py_compile pronostico_pm_cams.py`

------
https://chatgpt.com/codex/tasks/task_e_685238e1383c83319fb7e8d039d86e5a